### PR TITLE
chore(app): add root level script helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+    "scripts": {
+        "start:front": "cd javanotebook-front && npm start",
+        "start:db": "cd javanotebook/docker && docker-compose up -d",
+        "start:back": "cd javanotebook && mvn",
+        "stop:db": "cd javanotebook/docker && docker-compose down",
+        "build:front": "cd javanotebook-front && npm run build",
+        "build:back": "cd javanotebook && mvn package -Dmaven.test.skip=true"
+    }
+}


### PR DESCRIPTION
You can theses scripts with `npm run <SCRIPT_NAME>` exemple: `npm run start:db` 